### PR TITLE
fix(web): rely on base url when fetching logs

### DIFF
--- a/web/build.go
+++ b/web/build.go
@@ -113,7 +113,7 @@ func fsFile(w http.ResponseWriter, r *http.Request, file string, filesystem fs.F
 	http.ServeContent(w, r, file, stat.ModTime(), reader)
 }
 
-var validRoutes = []string{"/", "onboard", "login", "logout", "settings"}
+var validRoutes = []string{"/", "onboard", "login", "logout", "logs", "settings"}
 
 func validRoute(route string) bool {
 	for _, valid := range validRoutes {

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -10,6 +10,7 @@ import {
     LogKeys,
     PlexKeys,
 } from "@api/query_keys";
+import { baseUrl } from "@utils";
 
 export const ConfigQueryOptions = (enabled: boolean = true) =>
     queryOptions({
@@ -60,7 +61,7 @@ export const LogContentQueryOptions = (enabled: boolean = true) =>
     queryOptions({
         queryKey: LogKeys.content(),
         queryFn: async () => {
-            const response = await fetch(`${window.location.origin}/api/fs/logs/shinkro.log`);
+            const response = await fetch(`${window.location.origin}${baseUrl()}api/fs/logs/shinkro.log`);
             if (!response.ok) throw new Error("Failed to fetch log");
             return response.text();
         },

--- a/web/src/forms/settings/MalForm.tsx
+++ b/web/src/forms/settings/MalForm.tsx
@@ -5,7 +5,7 @@ import {useMutation} from "@tanstack/react-query";
 import {APIClient} from "@api/APIClient.ts";
 import {displayNotification} from "@components/notifications";
 import {useState} from "react";
-import {CopyTextToClipboard} from "@utils/index";
+import {baseUrl, CopyTextToClipboard} from "@utils/index";
 
 interface Props {
     opened: boolean;
@@ -17,7 +17,7 @@ interface Props {
 export const MalForm = ({opened, onClose, loading, setLoading}: Props) => {
     const [copied, setCopied] = useState(false);
     const [copyError, setCopyError] = useState(false);
-    const appRedirectURL = `${window.location.origin}${window.APP.baseUrl}malauth/callback`
+    const appRedirectURL = `${window.location.origin}${baseUrl()}malauth/callback`
 
     const form = useForm<MalAuth>({
         initialValues: {


### PR DESCRIPTION
Hi 👋, with `BaseUrl` set, it is impossible to view logs on the web UI because it does not respect the setting.

This PR handles this use case, and also adds `logs` to the valid routes list.