### PR TITLE
fix(animeupdate): only use direct AniDB DB lookup for season 1

### DIFF
--- a/internal/animeupdate/service.go
+++ b/internal/animeupdate/service.go
@@ -84,9 +84,11 @@ func (s *service) handleEvent(ctx context.Context, anime *domain.AnimeUpdate, is
 		return s.updateAndStore(ctx, anime, isScrobble)
 	}
 
-	// AniDB IDs are per-series/season; prefer direct DB lookup over TVDB conversion,
-	// which loses specificity when multiple series share a TVDB ID.
-	if anime.SourceDB == domain.AniDB {
+	// For season 1, the AniDB ID identifies the series, so a direct DB lookup is exact
+	// and avoids TVDB conversion collapsing multiple series onto a shared TVDB ID.
+	// For season > 1 the season number is the differentiator, so the community map
+	// (keyed by TVDB ID + season) must be used instead.
+	if anime.SourceDB == domain.AniDB && anime.SeasonNum == 1 {
 		req := &domain.GetAnimeRequest{IDtype: anime.SourceDB, Id: anime.SourceId}
 		if animeFromDB, err := s.animeService.GetByID(ctx, req); err == nil && animeFromDB.MALId > 0 {
 			anime.MALId = animeFromDB.MALId


### PR DESCRIPTION
## Summary

Fixes a regression from #128. That PR made AniDB sources do a direct DB lookup before TVDB conversion — but applied it to **all** seasons, short-circuiting the community map for season > 1.

For multi-season shows, HAMA reports the **base series** AniDB ID with the **season number** as the differentiator. The direct DB lookup ignores the season and returns the base series.

**Example (the reported regression):** `anidb-11370/4/11` (Re:Zero season 4) resolved to the original series **MAL 31240** instead of **MAL 61316** (Re:Zero 4th Season). The community map correctly keys this on `tvdbid 305089 + tvdbseason 4`.

## Fix

Gate the direct AniDB DB lookup behind `SeasonNum == 1`:
- **Season 1** → AniDB ID identifies the series → direct DB lookup (preserves the #128 Bleach fix, where distinct arcs share TVDB 74796)
- **Season > 1** → season differentiates → TVDB conversion + community map (as before #128)

## Test plan

- [ ] `anidb-11370/4/11` (Re:Zero S4) → MAL 61316 ✅
- [ ] `anidb-2369/1/366` (Bleach) → MAL 269 ✅ (regression guard from #128)
- [ ] `anidb-15449/1/13` (Bleach: Sennen Kessen Hen) → MAL 41467 ✅ (#128 case)